### PR TITLE
Fix Wi-Fi Interface Method Naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ let service = try LiveboxAPI(baseURLString: "http://192.168.1.1")
 // Authenticate when needed
 try await service.login(password: "yourpassword")
 
-// Alternative: Create service with authentication upfront (legacy style)
+// Alternative: Create service with authentication upfront
 let authenticatedService = try LiveboxAPI(
     baseURLString: "http://192.168.1.1",
     username: "admin",

--- a/Sources/Livebox/Service/LiveboxAPI.swift
+++ b/Sources/Livebox/Service/LiveboxAPI.swift
@@ -217,7 +217,7 @@ public class LiveboxAPI {
 
     /// Gets a specific router's Wi-Fi interface.
     /// - Parameters:
-    ///   - id: The ID of the Wi-Fi interface.
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
     ///   - completion: A callback to invoke with the result.
     /// - Returns: A URLSessionDataTask that can be used to cancel the request.
     @discardableResult

--- a/Sources/LiveboxAsync/LiveboxAPI+Async.swift
+++ b/Sources/LiveboxAsync/LiveboxAPI+Async.swift
@@ -107,13 +107,13 @@ extension LiveboxAPI {
     }
 
     /// Gets a specific router's Wi-Fi interface using async/await.
-    /// - Parameter id: The ID of the Wi-Fi interface.
+    /// - Parameter wlanIfc: The ID of the Wi-Fi interface.
     /// - Returns: The requested Wi-Fi interface.
     /// - Throws: An error if the request fails.
-    public func getWifiInterface(id: String) async throws(LiveboxError) -> WlanInterface {
+    public func getWlanInterface(wlanIfc: String) async throws(LiveboxError) -> WlanInterface {
         try await withErrorType(LiveboxError.self) {
             try await withCheckedThrowingContinuation { continuation in
-                _ = getWlanInterface(wlanIfc: id) { result in
+                _ = getWlanInterface(wlanIfc: wlanIfc) { result in
                     continuation.resume(with: result)
                 }
             }

--- a/Tests/LiveboxTests/Service/LiveboxAPIAsyncTests.swift
+++ b/Tests/LiveboxTests/Service/LiveboxAPIAsyncTests.swift
@@ -150,7 +150,7 @@ struct LiveboxAPIAsyncTests {
         mockClient.mockResponses[FeatureID.wlanInterface.id] = expectedInterface
 
         // When
-        let interface = try await service.getWifiInterface(id: "wl0")
+        let interface = try await service.getWlanInterface(wlanIfc: "wl0")
 
         // Then
         #expect(interface.id == "wl0")
@@ -164,7 +164,7 @@ struct LiveboxAPIAsyncTests {
 
         // When/Then
         do {
-            _ = try await service.getWifiInterface(id: "wl0")
+            _ = try await service.getWlanInterface(wlanIfc: "wl0")
             Issue.record("Expected failure but got success")
         } catch .featureNotFound(let message) {
             #expect(message == "WlanInterface")


### PR DESCRIPTION
### PR's key points
Standardizes Wi-Fi interface method naming.

### Changes
- **Breaking**: Renamed `getWifiInterface(id:)` to `getWlanInterface(wlanIfc:)` in async API for consistency
- Fixed parameter documentation to use correct `wlanIfc` parameter name
- Updated tests to use corrected method names