### PR TITLE
Add InterfaceType to DeviceInfo

### DIFF
--- a/Sources/Livebox/Models/DeviceInfo.swift
+++ b/Sources/Livebox/Models/DeviceInfo.swift
@@ -4,7 +4,7 @@ public struct DeviceInfo: Codable {
     public let ipV6Address: String
     public let hostName: String
     public let alias: String
-    public let interfaceType: String
+    public let interfaceType: InterfaceType
     public let active: Bool
 
     public init(
@@ -13,7 +13,7 @@ public struct DeviceInfo: Codable {
         ipV6Address: String,
         hostName: String,
         alias: String,
-        interfaceType: String,
+        interfaceType: InterfaceType,
         active: Bool
     ) {
         self.physAddress = physAddress
@@ -23,5 +23,30 @@ public struct DeviceInfo: Codable {
         self.alias = alias
         self.interfaceType = interfaceType
         self.active = active
+    }
+}
+
+extension DeviceInfo {
+    public enum InterfaceType: String, Codable {
+        case ethernet = "Ethernet"
+        case wifi = "Wifi"
+        case wifi24 = "Wifi24"
+        case wifi50 = "Wifi50"
+        case unknown = "Unknown"
+
+        public init?(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "ethernet":
+                self = .ethernet
+            case "wifi":
+                self = .wifi
+            case "wifi24":
+                self = .wifi24
+            case "wifi50":
+                self = .wifi50
+            default:
+                self = .unknown
+            }
+        }
     }
 }

--- a/Tests/LiveboxTests/Helpers/TestHelpers.swift
+++ b/Tests/LiveboxTests/Helpers/TestHelpers.swift
@@ -63,7 +63,7 @@ public enum TestHelpers {
         ipV6Address: String = "",
         hostName: String = "TestDevice",
         alias: String = "Test Device",
-        interfaceType: String = "Ethernet",
+        interfaceType: DeviceInfo.InterfaceType = .ethernet,
         active: Bool = true
     ) -> DeviceInfo {
         DeviceInfo(

--- a/Tests/LiveboxTests/Models/DeviceInfoTests.swift
+++ b/Tests/LiveboxTests/Models/DeviceInfoTests.swift
@@ -29,7 +29,7 @@ struct DeviceInfoTests {
         #expect(device.ipV6Address == "2001:db8::1")
         #expect(device.hostName == "MyDevice")
         #expect(device.alias == "Living Room TV")
-        #expect(device.interfaceType == "Ethernet")
+        #expect(device.interfaceType == .ethernet)
         #expect(device.active == true)
     }
 
@@ -57,7 +57,7 @@ struct DeviceInfoTests {
         #expect(device.ipV6Address == "")
         #expect(device.hostName == "")
         #expect(device.alias == "")
-        #expect(device.interfaceType == "WiFi")
+        #expect(device.interfaceType == .wifi)
         #expect(device.active == false)
     }
 
@@ -98,7 +98,7 @@ struct DeviceInfoTests {
         #expect(devices[0].ipAddress == "192.168.1.100")
         #expect(devices[0].hostName == "Device1")
         #expect(devices[0].alias == "Smart TV")
-        #expect(devices[0].interfaceType == "Ethernet")
+        #expect(devices[0].interfaceType == .ethernet)
         #expect(devices[0].active == true)
 
         // Second device
@@ -106,7 +106,7 @@ struct DeviceInfoTests {
         #expect(devices[1].ipAddress == "192.168.1.101")
         #expect(devices[1].hostName == "Device2")
         #expect(devices[1].alias == "iPhone")
-        #expect(devices[1].interfaceType == "WiFi")
+        #expect(devices[1].interfaceType == .wifi)
         #expect(devices[1].active == false)
     }
 
@@ -134,7 +134,7 @@ struct DeviceInfoTests {
         #expect(device.ipV6Address == "fe80::1")
         #expect(device.hostName == "iPhone-John")
         #expect(device.alias == "John's Phone")
-        #expect(device.interfaceType == "WiFi")
+        #expect(device.interfaceType == .wifi)
         #expect(device.active == true)
     }
 
@@ -146,7 +146,7 @@ struct DeviceInfoTests {
             ipV6Address: "2001:db8::1",
             hostName: "TestDevice",
             alias: "Test Device",
-            interfaceType: "Ethernet",
+            interfaceType: .ethernet,
             active: true
         )
 
@@ -187,7 +187,7 @@ struct DeviceInfoTests {
         #expect(device.ipV6Address == "")
         #expect(device.hostName == "")
         #expect(device.alias == "")
-        #expect(device.interfaceType == "")
+        #expect(device.interfaceType == .unknown)
         #expect(device.active == false)
     }
 
@@ -215,7 +215,7 @@ struct DeviceInfoTests {
         #expect(device.ipV6Address == "2001:db8::150")
         #expect(device.hostName == "Device-With_Special.Characters")
         #expect(device.alias == "Café's Smart TV (Living Room)")
-        #expect(device.interfaceType == "Ethernet/WiFi")
+        #expect(device.interfaceType == .unknown)
         #expect(device.active == true)
     }
 }

--- a/Tests/LiveboxTests/Service/LiveboxAPITests.swift
+++ b/Tests/LiveboxTests/Service/LiveboxAPITests.swift
@@ -470,7 +470,7 @@ struct LiveboxAPITests {
                 ipAddress: "192.168.1.100",
                 hostName: "Device1",
                 alias: "Smart TV",
-                interfaceType: "Ethernet",
+                interfaceType: .ethernet,
                 active: true
             ),
             TestHelpers.createTestDevice(
@@ -478,7 +478,7 @@ struct LiveboxAPITests {
                 ipAddress: "192.168.1.101",
                 hostName: "Device2",
                 alias: "iPhone",
-                interfaceType: "WiFi",
+                interfaceType: .wifi,
                 active: false
             ),
         ]
@@ -500,7 +500,7 @@ struct LiveboxAPITests {
             #expect(devices[0].ipAddress == "192.168.1.100")
             #expect(devices[0].hostName == "Device1")
             #expect(devices[0].alias == "Smart TV")
-            #expect(devices[0].interfaceType == "Ethernet")
+            #expect(devices[0].interfaceType == .ethernet)
             #expect(devices[0].active == true)
 
             // Second device
@@ -508,7 +508,7 @@ struct LiveboxAPITests {
             #expect(devices[1].ipAddress == "192.168.1.101")
             #expect(devices[1].hostName == "Device2")
             #expect(devices[1].alias == "iPhone")
-            #expect(devices[1].interfaceType == "WiFi")
+            #expect(devices[1].interfaceType == .wifi)
             #expect(devices[1].active == false)
 
         case .failure(let error):
@@ -573,7 +573,7 @@ struct LiveboxAPITests {
                 ipAddress: "192.168.1.100",
                 hostName: "EthernetDevice",
                 alias: "Desktop PC",
-                interfaceType: "Ethernet",
+                interfaceType: .ethernet,
                 active: true
             ),
             TestHelpers.createTestDevice(
@@ -581,15 +581,15 @@ struct LiveboxAPITests {
                 ipAddress: "192.168.1.101",
                 hostName: "WiFiDevice",
                 alias: "Smartphone",
-                interfaceType: "WiFi",
+                interfaceType: .wifi,
                 active: true
             ),
             TestHelpers.createTestDevice(
                 physAddress: "77:88:99:AA:BB:CC",
                 ipAddress: "192.168.1.102",
-                hostName: "PowerlineDevice",
+                hostName: "WiFi5Device",
                 alias: "Smart TV",
-                interfaceType: "Powerline",
+                interfaceType: .wifi50,
                 active: false
             ),
         ]
@@ -608,9 +608,9 @@ struct LiveboxAPITests {
 
             // Verify different interface types
             let interfaceTypes = Set(devices.map { $0.interfaceType })
-            #expect(interfaceTypes.contains("Ethernet"))
-            #expect(interfaceTypes.contains("WiFi"))
-            #expect(interfaceTypes.contains("Powerline"))
+            #expect(interfaceTypes.contains(.ethernet))
+            #expect(interfaceTypes.contains(.wifi))
+            #expect(interfaceTypes.contains(.wifi50))
 
         case .failure(let error):
             Issue.record("Expected success but got error: \(error)")


### PR DESCRIPTION
This PR adds `InterfaceType` to `DeviceInfo` and also updates the related tests