### PR TITLE
Create WLAN schedule services

### DIFF
--- a/Sources/Livebox/Livebox.swift
+++ b/Sources/Livebox/Livebox.swift
@@ -77,7 +77,7 @@ import Foundation
 ///
 /// - `GeneralInfo`: Information about the router device
 /// - `Capabilities`: Router API capabilities and features
-public struct Livebox {
+public struct LiveboxInfo {
     /// The current version of the Livebox package.
-    public static let version = "1.0.0"
+    public static let version = "1.2.0"
 }

--- a/Sources/Livebox/Models/DeviceScheduleStatus.swift
+++ b/Sources/Livebox/Models/DeviceScheduleStatus.swift
@@ -1,4 +1,4 @@
-public struct ScheduleStatus: Codable {
+public struct DeviceScheduleStatus: Codable {
     public let mac: String
     public let status: Status
 
@@ -13,7 +13,7 @@ public struct ScheduleStatus: Codable {
     }
 }
 
-extension ScheduleStatus {
+extension DeviceScheduleStatus {
     public enum Status: String, Codable {
         case enabled = "Enabled"
         case disabled = "Disabled"

--- a/Sources/Livebox/Models/WlanScheduleStatus.swift
+++ b/Sources/Livebox/Models/WlanScheduleStatus.swift
@@ -1,0 +1,11 @@
+public struct WlanScheduleStatus: Codable {
+    public let isEnabled: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case isEnabled = "Enabled"
+    }
+
+    public init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+}

--- a/Sources/Livebox/Service/LiveboxAPI.swift
+++ b/Sources/Livebox/Service/LiveboxAPI.swift
@@ -408,4 +408,134 @@ public class LiveboxAPI {
             completion: completion
         )
     }
+
+    /// Retrieves the schedules from the router.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The MAC of the access point.
+    ///   - completion: A callback to invoke with the result.
+    /// - Returns: A URLSessionDataTask that can be used to cancel the request.
+    @discardableResult
+    public func getWlanSchedules(
+        wlanIfc: String,
+        wlanAp: String,
+        completion: @escaping (Result<Schedules, LiveboxError>) -> Void
+    ) -> URLSessionDataTask? {
+        client.requestFeature(
+            id: .wlanSchedule,
+            pathVariables: ["wlan_ifc": wlanIfc, "wlan_ap": wlanAp.removingColons],
+            method: .get,
+            completion: completion
+        )
+    }
+
+    /// Adds schedules to the router.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The MAC of the access point.
+    ///   - schedules: The schedules to add.
+    ///   - completion: A callback to invoke with the result.
+    /// - Returns: A URLSessionDataTask that can be used to cancel the request.
+    @discardableResult
+    public func addWlanSchedules(
+        wlanIfc: String,
+        wlanAp: String,
+        schedules: Schedules,
+        completion: @escaping (Result<Schedules, LiveboxError>) -> Void
+    ) -> URLSessionDataTask? {
+        client.requestFeature(
+            id: .wlanSchedule,
+            pathVariables: ["wlan_ifc": wlanIfc, "wlan_ap": wlanAp.removingColons],
+            method: .post,
+            body: schedules,
+            completion: completion
+        )
+    }
+
+    /// Deletes the router's schedule.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The MAC of the access point.
+    ///   - schedules: The schedules to delete.
+    ///   - completion: A callback to invoke with the result.
+    /// - Returns: A URLSessionDataTask that can be used to cancel the request.
+    @discardableResult
+    public func deleteWlanSchedules(
+        wlanIfc: String,
+        wlanAp: String,
+        schedules: Schedules,
+        completion: @escaping (Result<Schedules, LiveboxError>) -> Void
+    ) -> URLSessionDataTask? {
+        client.requestFeature(
+            id: .wlanSchedule,
+            pathVariables: ["wlan_ifc": wlanIfc, "wlan_ap": wlanAp.removingColons],
+            method: .delete,
+            body: schedules,
+            completion: completion
+        )
+    }
+
+    /// Retrieves the router's schedule.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The MAC of the access point.
+    ///   - completion: A callback to invoke with the result.
+    /// - Returns: A URLSessionDataTask that can be used to cancel the request.
+    @discardableResult
+    public func getWlanScheduleStatus(
+        wlanIfc: String,
+        wlanAp: String,
+        completion: @escaping (Result<WlanScheduleStatus, LiveboxError>) -> Void
+    ) -> URLSessionDataTask? {
+        client.requestFeature(
+            id: .wlanScheduleEnable,
+            pathVariables: ["wlan_ifc": wlanIfc, "wlan_ap": wlanAp.removingColons],
+            method: .get,
+            completion: completion
+        )
+    }
+
+    /// Changes the router's schedule status.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The MAC of the access point.
+    ///   - status: The status to set.
+    ///   - completion: A callback to invoke with the result.
+    /// - Returns: A URLSessionDataTask that can be used to cancel the request.
+    @discardableResult
+    public func changeWlanScheduleStatus(
+        wlanIfc: String,
+        wlanAp: String,
+        status: WlanScheduleStatus,
+        completion: @escaping (Result<Void, LiveboxError>) -> Void
+    ) -> URLSessionDataTask? {
+        client.requestFeature(
+            id: .wlanScheduleEnable,
+            pathVariables: ["wlan_ifc": wlanIfc, "wlan_ap": wlanAp.removingColons],
+            method: .put,
+            body: status
+        ) { (result: Result<EmptyResponse, LiveboxError>) in
+            switch result {
+            case .success:
+                completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
 }

--- a/Sources/Livebox/Service/LiveboxAPI.swift
+++ b/Sources/Livebox/Service/LiveboxAPI.swift
@@ -372,7 +372,7 @@ public class LiveboxAPI {
     @discardableResult
     public func changeDeviceScheduleStatus(
         mac: String,
-        status: ScheduleStatus,
+        status: DeviceScheduleStatus,
         completion: @escaping (Result<Void, LiveboxError>) -> Void
     ) -> URLSessionDataTask? {
         client.requestFeature(

--- a/Sources/Livebox/Service/LiveboxAPI.swift
+++ b/Sources/Livebox/Service/LiveboxAPI.swift
@@ -484,7 +484,7 @@ public class LiveboxAPI {
         )
     }
 
-    /// Retrieves the router's schedule.
+    /// Retrieves the router's WLAN schedule status (enable/disable state).
     ///
     /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
     ///

--- a/Sources/Livebox/Service/LiveboxAPI.swift
+++ b/Sources/Livebox/Service/LiveboxAPI.swift
@@ -458,7 +458,7 @@ public class LiveboxAPI {
         )
     }
 
-    /// Deletes the router's schedule.
+    /// Deletes the specified schedules.
     ///
     /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
     ///

--- a/Sources/LiveboxAsync/LiveboxAPI+Async.swift
+++ b/Sources/LiveboxAsync/LiveboxAPI+Async.swift
@@ -236,7 +236,7 @@ extension LiveboxAPI {
     /// - Parameters:
     ///   - mac: The MAC of the device.
     ///   - status: The status to set.
-    public func changeDeviceScheduleStatus(mac: String, status: ScheduleStatus) async throws(LiveboxError) {
+    public func changeDeviceScheduleStatus(mac: String, status: DeviceScheduleStatus) async throws(LiveboxError) {
         try await withErrorType(LiveboxError.self) {
             try await withCheckedThrowingContinuation { continuation in
                 changeDeviceScheduleStatus(mac: mac, status: status) { result in

--- a/Sources/LiveboxAsync/LiveboxAPI+Async.swift
+++ b/Sources/LiveboxAsync/LiveboxAPI+Async.swift
@@ -247,6 +247,9 @@ extension LiveboxAPI {
     }
 
     /// Deletes the schedules of a specific device.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
     /// - Parameters:
     ///   - mac: The MAC of the device.
     ///   - schedules: The schedules to delete.
@@ -255,6 +258,103 @@ extension LiveboxAPI {
         try await withErrorType(LiveboxError.self) {
             try await withCheckedThrowingContinuation { continuation in
                 deleteDeviceSchedules(mac: mac, schedules: schedules) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Retrieves the schedules from the router.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The ID of the access point.
+    /// - Returns: The schedules of the WLAN access point.
+    /// - Throws: An error if the request fails.
+    public func getWlanSchedules(wlanIfc: String, wlanAp: String) async throws(LiveboxError) -> Schedules {
+        try await withErrorType(LiveboxError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                getWlanSchedules(wlanIfc: wlanIfc, wlanAp: wlanAp) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Adds schedules to the router.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The ID of the access point.
+    ///   - schedules: The schedules to add.
+    /// - Returns: The updated schedules of the WLAN access point.
+    /// - Throws: An error if the request fails.
+    public func addWlanSchedules(wlanIfc: String, wlanAp: String, schedules: Schedules) async throws(LiveboxError) -> Schedules {
+        try await withErrorType(LiveboxError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                addWlanSchedules(wlanIfc: wlanIfc, wlanAp: wlanAp, schedules: schedules) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Deletes the router's schedule.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The ID of the access point.
+    ///   - schedules: The schedules to delete.
+    /// - Returns: The updated schedules of the WLAN access point.
+    /// - Throws: An error if the request fails.
+    public func deleteWlanSchedules(wlanIfc: String, wlanAp: String, schedules: Schedules) async throws(LiveboxError) -> Schedules {
+        try await withErrorType(LiveboxError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                deleteWlanSchedules(wlanIfc: wlanIfc, wlanAp: wlanAp, schedules: schedules) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Retrieves the router's schedule.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The ID of the access point.
+    /// - Returns: The schedule status of the WLAN access point.
+    /// - Throws: An error if the request fails.
+    public func getWlanScheduleStatus(wlanIfc: String, wlanAp: String) async throws(LiveboxError) -> WlanScheduleStatus {
+        try await withErrorType(LiveboxError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                getWlanScheduleStatus(wlanIfc: wlanIfc, wlanAp: wlanAp) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        }
+    }
+
+    /// Changes the router's schedule status.
+    ///
+    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
+    ///
+    /// - Parameters:
+    ///   - wlanIfc: The ID of the Wi-Fi interface.
+    ///   - wlanAp: The ID of the access point.
+    ///   - status: The new schedule status to set.
+    /// - Throws: An error if the request fails.
+    public func changeWlanScheduleStatus(wlanIfc: String, wlanAp: String, status: WlanScheduleStatus) async throws(LiveboxError) {
+        try await withErrorType(LiveboxError.self) {
+            try await withCheckedThrowingContinuation { continuation in
+                changeWlanScheduleStatus(wlanIfc: wlanIfc, wlanAp: wlanAp, status: status) { result in
                     continuation.resume(with: result)
                 }
             }

--- a/Sources/LiveboxAsync/LiveboxAPI+Async.swift
+++ b/Sources/LiveboxAsync/LiveboxAPI+Async.swift
@@ -267,7 +267,7 @@ extension LiveboxAPI {
     ///
     /// - Parameters:
     ///   - wlanIfc: The ID of the Wi-Fi interface.
-    ///   - wlanAp: The ID of the access point.
+    ///   - wlanAp: The MAC of the access point.
     /// - Returns: The schedules of the WLAN access point.
     /// - Throws: An error if the request fails.
     public func getWlanSchedules(wlanIfc: String, wlanAp: String) async throws(LiveboxError) -> Schedules {
@@ -286,7 +286,7 @@ extension LiveboxAPI {
     ///
     /// - Parameters:
     ///   - wlanIfc: The ID of the Wi-Fi interface.
-    ///   - wlanAp: The ID of the access point.
+    ///   - wlanAp: The MAC of the access point.
     ///   - schedules: The schedules to add.
     /// - Returns: The updated schedules of the WLAN access point.
     /// - Throws: An error if the request fails.
@@ -306,7 +306,7 @@ extension LiveboxAPI {
     ///
     /// - Parameters:
     ///   - wlanIfc: The ID of the Wi-Fi interface.
-    ///   - wlanAp: The ID of the access point.
+    ///   - wlanAp: The MAC of the access point.
     ///   - schedules: The schedules to delete.
     /// - Returns: The updated schedules of the WLAN access point.
     /// - Throws: An error if the request fails.
@@ -326,7 +326,7 @@ extension LiveboxAPI {
     ///
     /// - Parameters:
     ///   - wlanIfc: The ID of the Wi-Fi interface.
-    ///   - wlanAp: The ID of the access point.
+    ///   - wlanAp: The MAC of the access point.
     /// - Returns: The schedule status of the WLAN access point.
     /// - Throws: An error if the request fails.
     public func getWlanScheduleStatus(wlanIfc: String, wlanAp: String) async throws(LiveboxError) -> WlanScheduleStatus {
@@ -345,7 +345,7 @@ extension LiveboxAPI {
     ///
     /// - Parameters:
     ///   - wlanIfc: The ID of the Wi-Fi interface.
-    ///   - wlanAp: The ID of the access point.
+    ///   - wlanAp: The MAC of the access point.
     ///   - status: The new schedule status to set.
     /// - Throws: An error if the request fails.
     public func changeWlanScheduleStatus(wlanIfc: String, wlanAp: String, status: WlanScheduleStatus) async throws(LiveboxError) {

--- a/Sources/LiveboxAsync/LiveboxAPI+Async.swift
+++ b/Sources/LiveboxAsync/LiveboxAPI+Async.swift
@@ -247,9 +247,6 @@ extension LiveboxAPI {
     }
 
     /// Deletes the schedules of a specific device.
-    ///
-    /// - Warning: Despite requiring a WLAN interface and access point ID, this service affects the entire router.
-    ///
     /// - Parameters:
     ///   - mac: The MAC of the device.
     ///   - schedules: The schedules to delete.

--- a/Sources/LiveboxAsync/LiveboxAsync.swift
+++ b/Sources/LiveboxAsync/LiveboxAsync.swift
@@ -47,7 +47,7 @@ import Livebox
 /// the flexibility to choose between callback-based and async/await patterns based on their needs.
 public struct LiveboxAsync {
     /// The current version of the LiveboxAsync package.
-    public static let version = Livebox.version
+    public static let version = LiveboxInfo.version
 
     private init() {}
 }

--- a/Tests/LiveboxTests/Service/LiveboxAPIAsyncTests.swift
+++ b/Tests/LiveboxTests/Service/LiveboxAPIAsyncTests.swift
@@ -274,7 +274,7 @@ struct LiveboxAPIAsyncTests {
     func testChangeDeviceScheduleStatusAsyncSuccess() async throws {
         // Given
         let mac = "AA:BB:CC:DD:EE:FF"
-        let status = ScheduleStatus(mac: mac, status: .enabled)
+        let status = DeviceScheduleStatus(mac: mac, status: .enabled)
         mockClient.mockResponses[FeatureID.pcDevicesMac.id] = ()
 
         // When
@@ -290,7 +290,7 @@ struct LiveboxAPIAsyncTests {
     func testChangeDeviceScheduleStatusAsyncFailure() async throws {
         // Given
         let mac = "AA:BB:CC:DD:EE:FF"
-        let status = ScheduleStatus(mac: mac, status: .disabled)
+        let status = DeviceScheduleStatus(mac: mac, status: .disabled)
         mockClient.mockErrors["PcDevicesMac"] = LiveboxError.featureNotFound("PcDevicesMac")
 
         // When/Then

--- a/Tests/LiveboxTests/Service/LiveboxAPIAsyncTests.swift
+++ b/Tests/LiveboxTests/Service/LiveboxAPIAsyncTests.swift
@@ -442,4 +442,75 @@ struct LiveboxAPIAsyncTests {
             #expect(message == "ConnectedDevices")
         }
     }
+
+    @Test("Get WLAN schedule status async success")
+    func testGetWlanScheduleStatusAsyncSuccess() async throws {
+        // Given
+        let wlanIfc = "wl0"
+        let wlanAp = "ap0"
+        let expectedStatus = WlanScheduleStatus(isEnabled: true)
+        mockClient.mockResponses[FeatureID.wlanScheduleEnable.id] = expectedStatus
+
+        // When
+        let status = try await service.getWlanScheduleStatus(wlanIfc: wlanIfc, wlanAp: wlanAp)
+
+        // Then
+        #expect(status.isEnabled == true)
+        let lastRequest = mockClient.requestLog.last
+        #expect(lastRequest?.endpoint.contains("WlanScheduleEnable") == true)
+        #expect(lastRequest?.endpoint.contains(wlanIfc) == true)
+        #expect(lastRequest?.endpoint.contains(wlanAp) == true)
+    }
+
+    @Test("Get WLAN schedule status async failure")
+    func testGetWlanScheduleStatusAsyncFailure() async throws {
+        // Given
+        let wlanIfc = "wl0"
+        let wlanAp = "ap0"
+        mockClient.mockErrors["WlanScheduleEnable"] = LiveboxError.featureNotFound("WlanScheduleEnable")
+
+        // When/Then
+        do {
+            _ = try await service.getWlanScheduleStatus(wlanIfc: wlanIfc, wlanAp: wlanAp)
+            Issue.record("Expected failure but got success")
+        } catch .featureNotFound(let message) {
+            #expect(message == "WlanScheduleEnable")
+        }
+    }
+
+    @Test("Change WLAN schedule status async success")
+    func testChangeWlanScheduleStatusAsyncSuccess() async throws {
+        // Given
+        let wlanIfc = "wl0"
+        let wlanAp = "ap0"
+        let status = WlanScheduleStatus(isEnabled: false)
+        mockClient.mockResponses[FeatureID.wlanScheduleEnable.id] = ()
+
+        // When
+        try await service.changeWlanScheduleStatus(wlanIfc: wlanIfc, wlanAp: wlanAp, status: status)
+
+        // Then
+        let lastRequest = mockClient.requestLog.last
+        #expect(lastRequest?.endpoint.contains("WlanScheduleEnable") == true)
+        #expect(lastRequest?.endpoint.contains(wlanIfc) == true)
+        #expect(lastRequest?.endpoint.contains(wlanAp) == true)
+        #expect(lastRequest?.method == .put)
+    }
+
+    @Test("Change WLAN schedule status async failure")
+    func testChangeWlanScheduleStatusAsyncFailure() async throws {
+        // Given
+        let wlanIfc = "wl0"
+        let wlanAp = "ap0"
+        let status = WlanScheduleStatus(isEnabled: true)
+        mockClient.mockErrors["WlanScheduleEnable"] = LiveboxError.featureNotFound("WlanScheduleEnable")
+
+        // When/Then
+        do {
+            try await service.changeWlanScheduleStatus(wlanIfc: wlanIfc, wlanAp: wlanAp, status: status)
+            Issue.record("Expected failure but got success")
+        } catch .featureNotFound(let message) {
+            #expect(message == "WlanScheduleEnable")
+        }
+    }
 }

--- a/Tests/LiveboxTests/Service/LiveboxAPITests.swift
+++ b/Tests/LiveboxTests/Service/LiveboxAPITests.swift
@@ -993,7 +993,7 @@ struct LiveboxAPITests {
     func testChangeDeviceScheduleStatusSuccess() async throws {
         // Given
         let mac = "AA:BB:CC:DD:EE:FF"
-        let status = ScheduleStatus(mac: mac, status: .enabled)
+        let status = DeviceScheduleStatus(mac: mac, status: .enabled)
         mockClient.mockResponses[FeatureID.pcDevicesMac.id] = ()
 
         // When
@@ -1019,7 +1019,7 @@ struct LiveboxAPITests {
     func testChangeDeviceScheduleStatusFailure() async throws {
         // Given
         let mac = "AA:BB:CC:DD:EE:FF"
-        let status = ScheduleStatus(mac: mac, status: .disabled)
+        let status = DeviceScheduleStatus(mac: mac, status: .disabled)
         mockClient.mockErrors["PcDevicesMac"] = LiveboxError.featureNotFound("PcDevicesMac")
 
         // When


### PR DESCRIPTION
This pull request introduces support for managing WLAN schedules on the router, including new API methods and corresponding async/await wrappers. It also refactors the device schedule status model for clarity and updates related tests to ensure correct behavior.