### PR TITLE
Add Accept: application/json header to all requests

### DIFF
--- a/Sources/Livebox/Client/DefaultLiveboxClient.swift
+++ b/Sources/Livebox/Client/DefaultLiveboxClient.swift
@@ -23,8 +23,8 @@ class DefaultLiveboxClient: LiveboxClient {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = configuration.timeout
         sessionConfig.timeoutIntervalForResource = configuration.timeout
-        sessionConfig.httpAdditionalHeaders = configuration.defaultHeaders.merging(["Accept": "application/json"]) { _, new in
-            new
+        sessionConfig.httpAdditionalHeaders = ["Accept": "application/json"].merging(configuration.defaultHeaders) { current, _ in
+            current
         }
 
         self.session = URLSession(configuration: sessionConfig)

--- a/Sources/Livebox/Client/DefaultLiveboxClient.swift
+++ b/Sources/Livebox/Client/DefaultLiveboxClient.swift
@@ -7,7 +7,7 @@ class DefaultLiveboxClient: LiveboxClient {
     var configuration: LiveboxClientConfiguration
 
     /// The URL session used for making network requests.
-    private let session: URLSession
+    internal let session: URLSession
 
     /// The capabilities of the router.
     private var capabilities: Capabilities?
@@ -23,6 +23,10 @@ class DefaultLiveboxClient: LiveboxClient {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = configuration.timeout
         sessionConfig.timeoutIntervalForResource = configuration.timeout
+        sessionConfig.httpAdditionalHeaders = configuration.defaultHeaders.merging(["Accept": "application/json"]) { _, new in
+            new
+        }
+
         self.session = URLSession(configuration: sessionConfig)
     }
 

--- a/Sources/Livebox/Livebox.swift
+++ b/Sources/Livebox/Livebox.swift
@@ -79,5 +79,5 @@ import Foundation
 /// - `Capabilities`: Router API capabilities and features
 public struct LiveboxInfo {
     /// The current version of the Livebox package.
-    public static let version = "1.2.0"
+    public static let version = "1.2.1"
 }

--- a/Sources/Livebox/Models/AccessPoint.swift
+++ b/Sources/Livebox/Models/AccessPoint.swift
@@ -179,9 +179,11 @@ extension AccessPoint {
     public enum BandwidthConf: RawRepresentable, Codable {
         case auto
         case _20mhz
-        case _20_40mhz
+        case _40mhz
         case _80mhz
         case _160mhz
+        case _20_40mhz
+        case _80_40_20mhz
         case unknown(String)
 
         public init?(rawValue: String) {
@@ -190,12 +192,16 @@ extension AccessPoint {
                 self = .auto
             case "20mhz":
                 self = ._20mhz
-            case "20/40mhz":
-                self = ._20_40mhz
+            case "40mhz":
+                self = ._40mhz
             case "80mhz":
                 self = ._80mhz
             case "160mhz":
                 self = ._160mhz
+            case "20/40mhz":
+                self = ._20_40mhz
+            case "80/40/20mhz":
+                self = ._80_40_20mhz
             default:
                 self = .unknown(rawValue)
             }
@@ -207,12 +213,16 @@ extension AccessPoint {
                 return "Auto"
             case ._20mhz:
                 return "20MHz"
-            case ._20_40mhz:
-                return "20/40MHz"
+            case ._40mhz:
+                return "40MHz"
             case ._80mhz:
                 return "80MHz"
             case ._160mhz:
                 return "160MHz"
+            case ._20_40mhz:
+                return "20/40MHz"
+            case ._80_40_20mhz:
+                return "80/40/20MHz"
             case .unknown(let value):
                 return value
             }

--- a/Tests/LiveboxTests/Client/LiveboxClientTests.swift
+++ b/Tests/LiveboxTests/Client/LiveboxClientTests.swift
@@ -16,6 +16,44 @@ struct LiveboxClientTests {
         #expect(config.defaultHeaders.isEmpty)
     }
 
+    @Test("Client session includes Accept header")
+    func testClientSessionIncludesAcceptHeader() {
+        let url = URL(string: "http://192.168.1.1")!
+        let client = DefaultLiveboxClient(baseURL: url)
+
+        let headers = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        #expect(headers?["Accept"] == "application/json")
+    }
+
+    @Test("Client session merges Accept header with custom headers")
+    func testClientSessionMergesAcceptHeaderWithCustomHeaders() {
+        let url = URL(string: "http://192.168.1.1")!
+        let config = LiveboxClientConfiguration(
+            baseURL: url,
+            defaultHeaders: ["User-Agent": "CustomAgent", "X-Custom": "Value"]
+        )
+        let client = DefaultLiveboxClient(configuration: config)
+
+        let headers = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        #expect(headers?["Accept"] == "application/json")
+        #expect(headers?["User-Agent"] == "CustomAgent")
+        #expect(headers?["X-Custom"] == "Value")
+    }
+
+    @Test("Default Accept header overrides custom Accept header")
+    func testDefaultAcceptHeaderOverridesCustom() {
+        let url = URL(string: "http://192.168.1.1")!
+        let config = LiveboxClientConfiguration(
+            baseURL: url,
+            defaultHeaders: ["Accept": "application/xml"]
+        )
+        let client = DefaultLiveboxClient(configuration: config)
+
+        let headers = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        // Default Accept: application/json header overrides any custom Accept header
+        #expect(headers?["Accept"] == "application/json")
+    }
+
     @Test("Client configuration initialization with custom parameters")
     func testConfigurationInitWithCustomParams() {
         let url = URL(string: "http://192.168.1.1")!
@@ -138,5 +176,52 @@ struct LiveboxClientTests {
         }
 
         #expect(client.configuration.baseURL == newURL)
+    }
+
+    @Test("Session headers remain unchanged after base URL update")
+    func testSessionHeadersUnchangedAfterBaseURLUpdate() throws {
+        // Session is created once and not recreated when base URL is updated
+        let client = try DefaultLiveboxClient(baseURLString: "http://192.168.1.1")
+
+        // Get initial session headers
+        let initialHeaders = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        #expect(initialHeaders?["Accept"] == "application/json")
+
+        // Update base URL
+        let newURL = URL(string: "http://192.168.1.100")!
+        client.updateBaseURL(newURL)
+
+        // Session headers should be unchanged (session is not recreated)
+        let updatedHeaders = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        #expect(updatedHeaders?["Accept"] == "application/json")
+        #expect(updatedHeaders == initialHeaders)
+    }
+
+    @Test("Session retains initial headers after base URL update with custom headers")
+    func testSessionRetainsInitialHeadersAfterBaseURLUpdate() throws {
+        // Create client with custom headers
+        let originalURL = URL(string: "http://192.168.1.1")!
+        let config = LiveboxClientConfiguration(
+            baseURL: originalURL,
+            defaultHeaders: ["User-Agent": "TestAgent", "X-Custom": "Value"]
+        )
+        let client = DefaultLiveboxClient(configuration: config)
+
+        // Verify initial session headers include Accept header and custom headers
+        let initialHeaders = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        #expect(initialHeaders?["Accept"] == "application/json")
+        #expect(initialHeaders?["User-Agent"] == "TestAgent")
+        #expect(initialHeaders?["X-Custom"] == "Value")
+
+        // Update base URL (note: this doesn't recreate the session)
+        let newURL = URL(string: "http://192.168.1.100")!
+        client.updateBaseURL(newURL)
+
+        // Session headers remain the same as when client was created
+        let updatedHeaders = client.session.configuration.httpAdditionalHeaders as? [String: String]
+        #expect(updatedHeaders?["Accept"] == "application/json")
+        #expect(updatedHeaders?["User-Agent"] == "TestAgent")
+        #expect(updatedHeaders?["X-Custom"] == "Value")
+        #expect(updatedHeaders == initialHeaders)
     }
 }


### PR DESCRIPTION
This pull request updates the Livebox client to ensure that all requests include a default `Accept: application/json` header, adding compatibility to older Livebox models.