### PR TITLE
Parse access point Idx from the response

### DIFF
--- a/Sources/Livebox/Models/WlanInterface.swift
+++ b/Sources/Livebox/Models/WlanInterface.swift
@@ -61,7 +61,7 @@ extension WlanInterface.Status {
 
 extension WlanInterface {
     public struct ShortAccessPoint: Codable {
-        /// Index of the access point
+        /// Index of the access point. If not provided during decoding, it is derived from the BSSID by removing colons
         public let idx: String
 
         /// BSSID of the access point
@@ -99,6 +99,23 @@ extension WlanInterface {
             self.ssid = ssid
             self.status = status
             self.remainingDuration = remainingDuration
+        }
+
+        /// Convenience initializer for backward compatibility.
+        /// Derives idx from bssid by removing colons.
+        public init(
+            bssid: String,
+            ssid: String,
+            status: Status,
+            remainingDuration: Int? = nil
+        ) {
+            self.init(
+                idx: bssid.removingColons,
+                bssid: bssid,
+                ssid: ssid,
+                status: status,
+                remainingDuration: remainingDuration
+            )
         }
 
         public init(from decoder: Decoder) throws {

--- a/Sources/Livebox/Models/WlanInterface.swift
+++ b/Sources/Livebox/Models/WlanInterface.swift
@@ -61,10 +61,8 @@ extension WlanInterface.Status {
 
 extension WlanInterface {
     public struct ShortAccessPoint: Codable {
-        /// Index of the access point. Uses the BSSID without the colon separators.
-        public var idx: String {
-            bssid.removingColons
-        }
+        /// Index of the access point
+        public let idx: String
 
         /// BSSID of the access point
         public let bssid: String
@@ -82,6 +80,7 @@ extension WlanInterface {
         public let remainingDuration: Int?
 
         enum CodingKeys: String, CodingKey {
+            case idx = "Idx"
             case bssid = "BSSID"
             case ssid = "SSID"
             case status = "Status"
@@ -89,15 +88,33 @@ extension WlanInterface {
         }
 
         public init(
+            idx: String,
             bssid: String,
             ssid: String,
             status: Status,
             remainingDuration: Int? = nil
         ) {
+            self.idx = idx
             self.bssid = bssid
             self.ssid = ssid
             self.status = status
             self.remainingDuration = remainingDuration
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            bssid = try container.decode(String.self, forKey: .bssid)
+            ssid = try container.decode(String.self, forKey: .ssid)
+            status = try container.decode(Status.self, forKey: .status)
+            remainingDuration = try container.decodeIfPresent(Int.self, forKey: .remainingDuration)
+
+            if let idx = try container.decodeIfPresent(String.self, forKey: .idx) {
+                self.idx = idx
+            } else {
+                // If "Idx" is missing, derive it from BSSID by removing colons
+                self.idx = bssid.removingColons
+            }
         }
     }
 }

--- a/Tests/LiveboxTests/Helpers/TestHelpers.swift
+++ b/Tests/LiveboxTests/Helpers/TestHelpers.swift
@@ -31,6 +31,7 @@ public enum TestHelpers {
             lastChange: 1_234_567_890,
             accessPoints: [
                 .init(
+                    idx: "001122334455",
                     bssid: "00:11:22:33:44:55",
                     ssid: "TestWiFi",
                     status: .up,


### PR DESCRIPTION
This pull request updates the `ShortAccessPoint` struct in `WlanInterface` to improve how the `idx` field is handled during encoding and decoding. The changes ensure that if the `Idx` field is missing in incoming JSON, it is derived from the `BSSID` by removing colons, and that this derived value is included when encoding back to JSON