### PR TITLE
Make ipAddress and ipV6Address optional

### DIFF
--- a/Sources/Livebox/Models/DeviceInfo.swift
+++ b/Sources/Livebox/Models/DeviceInfo.swift
@@ -1,7 +1,7 @@
 public struct DeviceInfo: Codable {
     public let physAddress: String
-    public let ipAddress: String
-    public let ipV6Address: String
+    public let ipAddress: String?
+    public let ipV6Address: String?
     public let hostName: String
     public let alias: String
     public let interfaceType: InterfaceType
@@ -9,8 +9,8 @@ public struct DeviceInfo: Codable {
 
     public init(
         physAddress: String,
-        ipAddress: String,
-        ipV6Address: String,
+        ipAddress: String?,
+        ipV6Address: String?,
         hostName: String,
         alias: String,
         interfaceType: InterfaceType,

--- a/Tests/LiveboxTests/Models/DeviceInfoTests.swift
+++ b/Tests/LiveboxTests/Models/DeviceInfoTests.swift
@@ -378,8 +378,8 @@ struct DeviceInfoTests {
         let encodedJson = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
 
         #expect(encodedJson["physAddress"] as? String == "AA:BB:CC:DD:EE:FF")
-        #expect(encodedJson["ipAddress"] == nil || (encodedJson["ipAddress"] as? NSNull) != nil)
-        #expect(encodedJson["ipV6Address"] == nil || (encodedJson["ipV6Address"] as? NSNull) != nil)
+        #expect((encodedJson["ipAddress"] as? NSNull) != nil)
+        #expect((encodedJson["ipV6Address"] as? NSNull) != nil)
         #expect(encodedJson["hostName"] as? String == "TestDevice")
         #expect(encodedJson["alias"] as? String == "Test Device")
         #expect(encodedJson["interfaceType"] as? String == "Wifi24")


### PR DESCRIPTION
Allow optional IpAddress and IpV6Address, as might return as nil on Livebox 6 Fast