### PR TITLE
Add ZTE support

### DIFF
--- a/Sources/Livebox/Extensions/KeyedDecodingContainer+AlternativeKeys.swift
+++ b/Sources/Livebox/Extensions/KeyedDecodingContainer+AlternativeKeys.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Extension to support alternative keys when decoding JSON with inconsistent key naming.
+///
+/// This is useful for handling different router manufacturers that may use different
+/// capitalizations for the same field (e.g., "idx" vs "Idx", "Manufacturer" vs "ManuFacturer").
+extension KeyedDecodingContainer {
+    /// Decodes a value for the first key that exists in the container.
+    ///
+    /// Attempts to decode using each provided key in order until one succeeds.
+    /// Throws an error if none of the keys exist or if decoding fails for all keys.
+    ///
+    /// - Parameters:
+    ///   - type: The type to decode.
+    ///   - keys: One or more keys to try, in order of preference.
+    /// - Returns: The decoded value.
+    /// - Throws: `DecodingError.keyNotFound` if none of the keys exist,
+    ///           or other decoding errors if the value cannot be decoded.
+    ///
+    /// Example:
+    /// ```swift
+    /// enum CodingKeys: String, CodingKey {
+    ///     case manufacturer = "Manufacturer"
+    ///     case manufacturerAlt = "ManuFacturer"
+    /// }
+    ///
+    /// // Try "Manufacturer" first, then "ManuFacturer" as fallback
+    /// manufacturer = try container.decode(String.self, forFirstOf: .manufacturer, .manufacturerAlt)
+    /// ```
+    func decode<T: Decodable>(_ type: T.Type, forFirstOf keys: Key...) throws -> T {
+        var lastError: Error?
+
+        for key in keys {
+            do {
+                return try decode(T.self, forKey: key)
+            } catch {
+                lastError = error
+                continue
+            }
+        }
+
+        // If we get here, none of the keys worked
+        let context = DecodingError.Context(
+            codingPath: codingPath,
+            debugDescription: "Could not decode \(type) for any of the keys: \(keys.map { $0.stringValue }.joined(separator: ", "))"
+        )
+        throw lastError ?? DecodingError.keyNotFound(keys[0], context)
+    }
+
+    /// Decodes an optional value for the first key that exists in the container.
+    ///
+    /// Attempts to decode using each provided key in order until one succeeds.
+    /// Returns `nil` if none of the keys exist or if the value is `null`.
+    ///
+    /// - Parameters:
+    ///   - type: The type to decode.
+    ///   - keys: One or more keys to try, in order of preference.
+    /// - Returns: The decoded value, or `nil` if none of the keys exist or the value is `null`.
+    ///
+    /// Example:
+    /// ```swift
+    /// enum CodingKeys: String, CodingKey {
+    ///     case idx = "idx"
+    ///     case idxAlt = "Idx"
+    /// }
+    ///
+    /// // Try "idx" first, then "Idx" as fallback
+    /// idx = container.decodeIfPresent(String.self, forFirstOf: .idx, .idxAlt)
+    /// ```
+    func decodeIfPresent<T: Decodable>(_ type: T.Type, forFirstOf keys: Key...) -> T? {
+        for key in keys {
+            if let value = try? decodeIfPresent(T.self, forKey: key) {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Livebox/Livebox.swift
+++ b/Sources/Livebox/Livebox.swift
@@ -77,5 +77,5 @@ import Foundation
 /// - `Capabilities`: Router API capabilities and features
 public struct LiveboxInfo {
     /// The current version of the Livebox package.
-    public static let version = "1.3.0"
+    public static let version = "1.4.0"
 }

--- a/Sources/Livebox/Models/AccessPoint.swift
+++ b/Sources/Livebox/Models/AccessPoint.swift
@@ -145,7 +145,7 @@ public struct AccessPoint: Codable {
         try container.encodeIfPresent(maxStations, forKey: .maxStations)
         try container.encodeIfPresent(apBridgeDisable, forKey: .apBridgeDisable)
         try container.encode(channelConf, forKey: .channelConf)
-        try container.encode(channel, forKey: .channel)
+        try container.encodeIfPresent(channel, forKey: .channel)
         try container.encode(bandwidthConf, forKey: .bandwidthConf)
         try container.encode(bandwidth, forKey: .bandwidth)
         try container.encodeIfPresent(mode, forKey: .mode)
@@ -213,7 +213,7 @@ extension AccessPoint {
         case guest
         case unknown(String)
 
-        public init?(rawValue: String) {
+        public init(rawValue: String) {
             switch rawValue.lowercased() {
             case "home":
                 self = .home

--- a/Sources/Livebox/Models/DeviceScheduleStatus.swift
+++ b/Sources/Livebox/Models/DeviceScheduleStatus.swift
@@ -17,5 +17,16 @@ extension DeviceScheduleStatus {
     public enum Status: String, Codable {
         case enabled = "Enabled"
         case disabled = "Disabled"
+
+        public init?(rawValue: String) {
+            switch rawValue.lowercased() {
+            case "enabled":
+                self = .enabled
+            case "disabled":
+                self = .disabled
+            default:
+                return nil
+            }
+        }
     }
 }

--- a/Sources/Livebox/Models/FlexibleInt.swift
+++ b/Sources/Livebox/Models/FlexibleInt.swift
@@ -1,0 +1,28 @@
+@propertyWrapper
+public struct FlexibleInt: Codable {
+    public var wrappedValue: Int?
+
+    public init(wrappedValue: Int?) {
+        self.wrappedValue = wrappedValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let intValue = try? container.decode(Int.self) {
+            wrappedValue = intValue
+        } else if let stringValue = try? container.decode(String.self),
+            let intValue = Int(stringValue) {
+            wrappedValue = intValue
+        } else if container.decodeNil() {
+            wrappedValue = nil
+        } else {
+            wrappedValue = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wrappedValue)
+    }
+}

--- a/Sources/Livebox/Models/FlexibleInt.swift
+++ b/Sources/Livebox/Models/FlexibleInt.swift
@@ -11,13 +11,15 @@ public struct FlexibleInt: Codable {
 
         if let intValue = try? container.decode(Int.self) {
             wrappedValue = intValue
-        } else if let stringValue = try? container.decode(String.self),
-            let intValue = Int(stringValue) {
+        } else if let stringValue = try? container.decode(String.self), let intValue = Int(stringValue) {
             wrappedValue = intValue
         } else if container.decodeNil() {
             wrappedValue = nil
         } else {
-            wrappedValue = nil
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Expected Int or String convertible to Int, but found invalid value"
+            )
         }
     }
 

--- a/Sources/Livebox/Models/GeneralInfo.swift
+++ b/Sources/Livebox/Models/GeneralInfo.swift
@@ -47,7 +47,7 @@ public struct GeneralInfo: Codable {
     /// Provisioning code
     public let provisioningCode: String?
 
-    /// Uptime in seconds (can come as Int or String from different routers)
+    /// Uptime in seconds. Uses @FlexibleInt to support both Int and String values from different routers (e.g., ZTE routers may send this as a string)
     @FlexibleInt public var upTime: Int?
 
     /// First use date

--- a/Sources/Livebox/Models/GeneralInfo.swift
+++ b/Sources/Livebox/Models/GeneralInfo.swift
@@ -47,8 +47,8 @@ public struct GeneralInfo: Codable {
     /// Provisioning code
     public let provisioningCode: String?
 
-    /// Uptime in seconds
-    public let upTime: Int?
+    /// Uptime in seconds (can come as Int or String from different routers)
+    @FlexibleInt public var upTime: Int?
 
     /// First use date
     public let firstUseDate: String?
@@ -82,36 +82,6 @@ public struct GeneralInfo: Codable {
 
     /// Router name (mandatory since v2.2.7)
     public let routerName: String?
-
-    private enum CodingKeys: String, CodingKey {
-        case manufacturer = "Manufacturer"
-        case manufacturerOUI = "ManufacturerOUI"
-        case modelName = "ModelName"
-        case description = "Description"
-        case productClass = "ProductClass"
-        case serialNumber = "SerialNumber"
-        case hardwareVersion = "HardwareVersion"
-        case softwareVersion = "SoftwareVersion"
-        case rescueVersion = "RescueVersion"
-        case modemFirmwareVersion = "ModemFirmwareVersion"
-        case enabledOptions = "EnabledOptions"
-        case additionalHardwareVersion = "AdditionalHardwareVersion"
-        case additionalSoftwareVersion = "AdditionalSoftwareVersion"
-        case specVersion = "SpecVersion"
-        case provisioningCode = "ProvisioningCode"
-        case upTime = "UpTime"
-        case firstUseDate = "FirstUseDate"
-        case deviceLog = "DeviceLog"
-        case manufacturerURL = "ManufacturerURL"
-        case country = "Country"
-        case numberOfReboots = "NumberOfReboots"
-        case upgradeOccurred = "UpgradeOccurred"
-        case resetOccurred = "ResetOccurred"
-        case restoreOccurred = "RestoreOccurred"
-        case apiVersion = "ApiVersion"
-        case routerImage = "RouterImage"
-        case routerName = "RouterName"
-    }
 
     public init(
         manufacturer: String,
@@ -157,7 +127,7 @@ public struct GeneralInfo: Codable {
         self.additionalSoftwareVersion = additionalSoftwareVersion
         self.specVersion = specVersion
         self.provisioningCode = provisioningCode
-        self.upTime = upTime
+        self._upTime = FlexibleInt(wrappedValue: upTime)
         self.firstUseDate = firstUseDate
         self.deviceLog = deviceLog
         self.manufacturerURL = manufacturerURL
@@ -169,5 +139,106 @@ public struct GeneralInfo: Codable {
         self.apiVersion = apiVersion
         self.routerImage = routerImage
         self.routerName = routerName
+    }
+
+    // MARK: - Codable conformance
+
+    enum CodingKeys: String, CodingKey {
+        case manufacturer = "Manufacturer"
+        case manufacturerAlt = "ManuFacturer"  // ZTE router variant
+        case manufacturerOUI = "ManufacturerOUI"
+        case modelName = "ModelName"
+        case description = "Description"
+        case productClass = "ProductClass"
+        case serialNumber = "SerialNumber"
+        case hardwareVersion = "HardwareVersion"
+        case softwareVersion = "SoftwareVersion"
+        case rescueVersion = "RescueVersion"
+        case modemFirmwareVersion = "ModemFirmwareVersion"
+        case enabledOptions = "EnabledOptions"
+        case additionalHardwareVersion = "AdditionalHardwareVersion"
+        case additionalSoftwareVersion = "AdditionalSoftwareVersion"
+        case specVersion = "SpecVersion"
+        case provisioningCode = "ProvisioningCode"
+        case upTime = "UpTime"
+        case firstUseDate = "FirstUseDate"
+        case deviceLog = "DeviceLog"
+        case manufacturerURL = "ManufacturerURL"
+        case country = "Country"
+        case numberOfReboots = "NumberOfReboots"
+        case upgradeOccurred = "UpgradeOccurred"
+        case resetOccurred = "ResetOccurred"
+        case restoreOccurred = "RestoreOccurred"
+        case apiVersion = "ApiVersion"
+        case routerImage = "RouterImage"
+        case routerName = "RouterName"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Handle Manufacturer field that may come as "Manufacturer" or "ManuFacturer" (ZTE)
+        self.manufacturer = try container.decode(String.self, forFirstOf: .manufacturer, .manufacturerAlt)
+        self.manufacturerOUI = try container.decodeIfPresent(String.self, forKey: .manufacturerOUI)
+        self.modelName = try container.decode(String.self, forKey: .modelName)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.productClass = try container.decode(String.self, forKey: .productClass)
+        self.serialNumber = try container.decode(String.self, forKey: .serialNumber)
+        self.hardwareVersion = try container.decode(String.self, forKey: .hardwareVersion)
+        self.softwareVersion = try container.decode(String.self, forKey: .softwareVersion)
+        self.rescueVersion = try container.decodeIfPresent(String.self, forKey: .rescueVersion)
+        self.modemFirmwareVersion = try container.decodeIfPresent(String.self, forKey: .modemFirmwareVersion)
+        self.enabledOptions = try container.decodeIfPresent(String.self, forKey: .enabledOptions)
+        self.additionalHardwareVersion = try container.decodeIfPresent(String.self, forKey: .additionalHardwareVersion)
+        self.additionalSoftwareVersion = try container.decodeIfPresent(String.self, forKey: .additionalSoftwareVersion)
+        self.specVersion = try container.decodeIfPresent(String.self, forKey: .specVersion)
+        self.provisioningCode = try container.decodeIfPresent(String.self, forKey: .provisioningCode)
+
+        // UpTime uses @FlexibleInt to handle both Int and String values
+        self._upTime = try container.decodeIfPresent(FlexibleInt.self, forKey: .upTime) ?? FlexibleInt(wrappedValue: nil)
+
+        self.firstUseDate = try container.decodeIfPresent(String.self, forKey: .firstUseDate)
+        self.deviceLog = try container.decodeIfPresent(String.self, forKey: .deviceLog)
+        self.manufacturerURL = try container.decodeIfPresent(String.self, forKey: .manufacturerURL)
+        self.country = try container.decodeIfPresent(String.self, forKey: .country)
+        self.numberOfReboots = try container.decodeIfPresent(Int.self, forKey: .numberOfReboots)
+        self.upgradeOccurred = try container.decodeIfPresent(Bool.self, forKey: .upgradeOccurred)
+        self.resetOccurred = try container.decodeIfPresent(Bool.self, forKey: .resetOccurred)
+        self.restoreOccurred = try container.decodeIfPresent(Bool.self, forKey: .restoreOccurred)
+        self.apiVersion = try container.decodeIfPresent(String.self, forKey: .apiVersion)
+        self.routerImage = try container.decodeIfPresent(String.self, forKey: .routerImage)
+        self.routerName = try container.decodeIfPresent(String.self, forKey: .routerName)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(manufacturer, forKey: .manufacturer)
+        try container.encodeIfPresent(manufacturerOUI, forKey: .manufacturerOUI)
+        try container.encode(modelName, forKey: .modelName)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encode(productClass, forKey: .productClass)
+        try container.encode(serialNumber, forKey: .serialNumber)
+        try container.encode(hardwareVersion, forKey: .hardwareVersion)
+        try container.encode(softwareVersion, forKey: .softwareVersion)
+        try container.encodeIfPresent(rescueVersion, forKey: .rescueVersion)
+        try container.encodeIfPresent(modemFirmwareVersion, forKey: .modemFirmwareVersion)
+        try container.encodeIfPresent(enabledOptions, forKey: .enabledOptions)
+        try container.encodeIfPresent(additionalHardwareVersion, forKey: .additionalHardwareVersion)
+        try container.encodeIfPresent(additionalSoftwareVersion, forKey: .additionalSoftwareVersion)
+        try container.encodeIfPresent(specVersion, forKey: .specVersion)
+        try container.encodeIfPresent(provisioningCode, forKey: .provisioningCode)
+        try container.encodeIfPresent(_upTime, forKey: .upTime)
+        try container.encodeIfPresent(firstUseDate, forKey: .firstUseDate)
+        try container.encodeIfPresent(deviceLog, forKey: .deviceLog)
+        try container.encodeIfPresent(manufacturerURL, forKey: .manufacturerURL)
+        try container.encodeIfPresent(country, forKey: .country)
+        try container.encodeIfPresent(numberOfReboots, forKey: .numberOfReboots)
+        try container.encodeIfPresent(upgradeOccurred, forKey: .upgradeOccurred)
+        try container.encodeIfPresent(resetOccurred, forKey: .resetOccurred)
+        try container.encodeIfPresent(restoreOccurred, forKey: .restoreOccurred)
+        try container.encodeIfPresent(apiVersion, forKey: .apiVersion)
+        try container.encodeIfPresent(routerImage, forKey: .routerImage)
+        try container.encodeIfPresent(routerName, forKey: .routerName)
     }
 }

--- a/Tests/LiveboxTests/Models/AccessPointTests.swift
+++ b/Tests/LiveboxTests/Models/AccessPointTests.swift
@@ -111,6 +111,95 @@ struct AccessPointTests {
         #expect(accessPoint.apBridgeDisable == nil)
     }
 
+    @Test("Decoding AccessPoint with alternative key name (Idx)")
+    func testDecodingWithAlternativeKeyName() throws {
+        // Test with uppercase "Idx" (ZTE router variant)
+        let json = """
+            {
+                "Idx": "8C19B5F8EDA7",
+                "BSSID": "8C:19:B5:F8:ED:A7",
+                "Type": "Home",
+                "Manner": "Combined",
+                "Status": "Up",
+                "SSID": "Livebox-Network",
+                "Password": "securePassword123",
+                "ChannelConf": "Auto",
+                "Channel": 6,
+                "BandwithConf": "20MHz",
+                "Bandwith": "20MHz",
+                "Mode": "11ng",
+                "SchedulingAllowed": true
+            }
+            """
+
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let accessPoint = try decoder.decode(AccessPoint.self, from: jsonData)
+
+        #expect(accessPoint.idx == "8C19B5F8EDA7")
+        #expect(accessPoint.bssid == "8C:19:B5:F8:ED:A7")
+        #expect(accessPoint.type == .home)
+    }
+
+    @Test("Decoding AccessPoint with case-insensitive enum values")
+    func testDecodingCaseInsensitiveEnums() throws {
+        let json = """
+            {
+                "idx": "8C19B5F8EDA7",
+                "BSSID": "8C:19:B5:F8:ED:A7",
+                "Type": "home",
+                "Manner": "combined",
+                "Status": "up",
+                "SSID": "Livebox-Network",
+                "Password": "securePassword123",
+                "ChannelConf": "auto",
+                "Channel": 6,
+                "BandwithConf": "20MHz",
+                "Bandwith": "20MHz",
+                "Mode": "11ng",
+                "SchedulingAllowed": true
+            }
+            """
+
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let accessPoint = try decoder.decode(AccessPoint.self, from: jsonData)
+
+        #expect(accessPoint.type == .home)
+        #expect(accessPoint.manner == .combined)
+        #expect(accessPoint.status == .up)
+        #expect(accessPoint.channelConf == .auto)
+    }
+
+    @Test("Decoding AccessPoint with uppercase enum values")
+    func testDecodingUppercaseEnums() throws {
+        let json = """
+            {
+                "idx": "8C19B5F8EDA7",
+                "BSSID": "8C:19:B5:F8:ED:A7",
+                "Type": "GUEST",
+                "Manner": "SPLIT",
+                "Status": "DOWN",
+                "SSID": "Livebox-Guest",
+                "Password": "guestPassword123",
+                "ChannelConf": "AUTO2",
+                "Channel": 11,
+                "BandwithConf": "40MHz",
+                "Bandwith": "40MHz",
+                "SchedulingAllowed": false
+            }
+            """
+
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let accessPoint = try decoder.decode(AccessPoint.self, from: jsonData)
+
+        #expect(accessPoint.type == .guest)
+        #expect(accessPoint.manner == .split)
+        #expect(accessPoint.status == .down)
+        #expect(accessPoint.channelConf == .auto2)
+    }
+
     @Test("Encoding AccessPoint to JSON")
     func testEncoding() throws {
         let accessPoint = AccessPoint(
@@ -172,13 +261,14 @@ struct AccessPointTests {
     @Test("AccessPointType enum cases")
     func testAccessPointTypeEnum() {
         // Test creation from raw values
-        #expect(AccessPoint.AccessPointType(rawValue: "Home") == .home)
-        #expect(AccessPoint.AccessPointType(rawValue: "Guest") == .guest)
-        #expect(AccessPoint.AccessPointType(rawValue: "Unknown") == nil)
+        #expect(AccessPoint.AccessPointType(rawValue: "Home")! == .home)
+        #expect(AccessPoint.AccessPointType(rawValue: "Guest")! == .guest)
+        #expect(AccessPoint.AccessPointType(rawValue: "Unknown")! == .unknown("Unknown"))
 
         // Test raw values
         #expect(AccessPoint.AccessPointType.home.rawValue == "Home")
         #expect(AccessPoint.AccessPointType.guest.rawValue == "Guest")
+        #expect(AccessPoint.AccessPointType(rawValue: "Unknown")!.rawValue == "Unknown")
     }
 
     @Test("Manner enum cases")
@@ -203,6 +293,15 @@ struct AccessPointTests {
         // Test raw values
         #expect(AccessPoint.Status.up.rawValue == "Up")
         #expect(AccessPoint.Status.down.rawValue == "Down")
+    }
+
+    @Test("ChannelConf enum cases")
+    func testChannelConfEnum() {
+        // Test creation from raw values
+        #expect(AccessPoint.ChannelConf(rawValue: "Auto") == .auto)
+        #expect(AccessPoint.ChannelConf(rawValue: "Auto1") == .auto1)
+        #expect(AccessPoint.ChannelConf(rawValue: "Auto2") == .auto2)
+        #expect(AccessPoint.ChannelConf(rawValue: "Unknown") == nil)
     }
 
     @Test("Creating AccessPoint request")

--- a/Tests/LiveboxTests/Models/AccessPointTests.swift
+++ b/Tests/LiveboxTests/Models/AccessPointTests.swift
@@ -261,14 +261,14 @@ struct AccessPointTests {
     @Test("AccessPointType enum cases")
     func testAccessPointTypeEnum() {
         // Test creation from raw values
-        #expect(AccessPoint.AccessPointType(rawValue: "Home")! == .home)
-        #expect(AccessPoint.AccessPointType(rawValue: "Guest")! == .guest)
-        #expect(AccessPoint.AccessPointType(rawValue: "Unknown")! == .unknown("Unknown"))
+        #expect(AccessPoint.AccessPointType(rawValue: "Home") == .home)
+        #expect(AccessPoint.AccessPointType(rawValue: "Guest") == .guest)
+        #expect(AccessPoint.AccessPointType(rawValue: "Unknown") == .unknown("Unknown"))
 
         // Test raw values
         #expect(AccessPoint.AccessPointType.home.rawValue == "Home")
         #expect(AccessPoint.AccessPointType.guest.rawValue == "Guest")
-        #expect(AccessPoint.AccessPointType(rawValue: "Unknown")!.rawValue == "Unknown")
+        #expect(AccessPoint.AccessPointType(rawValue: "Unknown").rawValue == "Unknown")
     }
 
     @Test("Manner enum cases")

--- a/Tests/LiveboxTests/Models/DeviceScheduleStatusTests.swift
+++ b/Tests/LiveboxTests/Models/DeviceScheduleStatusTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import Livebox
+
+@Suite("DeviceScheduleStatus Tests")
+struct DeviceScheduleStatusTests {
+    @Test("Decoding DeviceScheduleStatus with enabled status")
+    func testDecodingEnabledStatus() throws {
+        let json = """
+            {
+                "MAC": "AA:BB:CC:DD:EE:FF",
+                "Status": "Enabled"
+            }
+            """
+
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let status = try decoder.decode(DeviceScheduleStatus.self, from: jsonData)
+
+        #expect(status.mac == "AA:BB:CC:DD:EE:FF")
+        #expect(status.status == .enabled)
+    }
+
+    @Test("Decoding DeviceScheduleStatus with disabled status")
+    func testDecodingDisabledStatus() throws {
+        let json = """
+            {
+                "MAC": "11:22:33:44:55:66",
+                "Status": "Disabled"
+            }
+            """
+
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let status = try decoder.decode(DeviceScheduleStatus.self, from: jsonData)
+
+        #expect(status.mac == "11:22:33:44:55:66")
+        #expect(status.status == .disabled)
+    }
+
+    @Test("Encoding DeviceScheduleStatus to JSON")
+    func testEncodingDeviceScheduleStatus() throws {
+        let status = DeviceScheduleStatus(mac: "AA:BB:CC:DD:EE:FF", status: .enabled)
+
+        let encoder = JSONEncoder()
+        let encodedData = try encoder.encode(status)
+        let encodedJson = try JSONSerialization.jsonObject(with: encodedData) as! [String: Any]
+
+        #expect(encodedJson["MAC"] as? String == "AA:BB:CC:DD:EE:FF")
+        #expect(encodedJson["Status"] as? String == "Enabled")
+    }
+
+    @Test("Status enum initialization from raw values")
+    func testStatusEnumInitialization() {
+        // Test standard capitalization
+        #expect(DeviceScheduleStatus.Status(rawValue: "Enabled") == .enabled)
+        #expect(DeviceScheduleStatus.Status(rawValue: "Disabled") == .disabled)
+
+        // Test lowercase
+        #expect(DeviceScheduleStatus.Status(rawValue: "enabled") == .enabled)
+        #expect(DeviceScheduleStatus.Status(rawValue: "disabled") == .disabled)
+
+        // Test uppercase
+        #expect(DeviceScheduleStatus.Status(rawValue: "ENABLED") == .enabled)
+        #expect(DeviceScheduleStatus.Status(rawValue: "DISABLED") == .disabled)
+
+        // Test mixed case
+        #expect(DeviceScheduleStatus.Status(rawValue: "EnAbLeD") == .enabled)
+        #expect(DeviceScheduleStatus.Status(rawValue: "DiSaBlEd") == .disabled)
+
+        // Test invalid values
+        #expect(DeviceScheduleStatus.Status(rawValue: "Unknown") == nil)
+        #expect(DeviceScheduleStatus.Status(rawValue: "Active") == nil)
+        #expect(DeviceScheduleStatus.Status(rawValue: "") == nil)
+    }
+
+    @Test("Status enum raw values")
+    func testStatusEnumRawValues() {
+        #expect(DeviceScheduleStatus.Status.enabled.rawValue == "Enabled")
+        #expect(DeviceScheduleStatus.Status.disabled.rawValue == "Disabled")
+    }
+
+    @Test("Decoding array of DeviceScheduleStatus")
+    func testDecodingArray() throws {
+        let json = """
+            [
+                {
+                    "MAC": "AA:BB:CC:DD:EE:FF",
+                    "Status": "Enabled"
+                },
+                {
+                    "MAC": "11:22:33:44:55:66",
+                    "Status": "disabled"
+                },
+                {
+                    "MAC": "99:88:77:66:55:44",
+                    "Status": "ENABLED"
+                }
+            ]
+            """
+
+        let jsonData = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let statuses = try decoder.decode([DeviceScheduleStatus].self, from: jsonData)
+
+        #expect(statuses.count == 3)
+        #expect(statuses[0].mac == "AA:BB:CC:DD:EE:FF")
+        #expect(statuses[0].status == .enabled)
+        #expect(statuses[1].mac == "11:22:33:44:55:66")
+        #expect(statuses[1].status == .disabled)
+        #expect(statuses[2].mac == "99:88:77:66:55:44")
+        #expect(statuses[2].status == .enabled)
+    }
+}


### PR DESCRIPTION
This PR adds support for ZTE models, including:
- Add KeyedDecodingContainer extension for alternative keys
- Add @FlexibleInt property wrapper for Int/String decoding
- Support case-insensitive enum decoding for models
- Handle ZTE router key variants in AccessPoint and GeneralInfo
- Add tests for alternative keys, flexible int, and enums