### PR TITLE
Use invoke for put or patch methods and increase timeout

### DIFF
--- a/Sources/Livebox/Client/LiveboxClientConfiguration.swift
+++ b/Sources/Livebox/Client/LiveboxClientConfiguration.swift
@@ -20,13 +20,13 @@ public struct LiveboxClientConfiguration {
     /// Creates a new configuration with the specified parameters.
     /// - Parameters:
     ///   - baseURL: The base URL for the router API.
-    ///   - timeout: The timeout for network requests in seconds. Default is 30 seconds.
+    ///   - timeout: The timeout for network requests in seconds. Default is 60 seconds.
     ///   - defaultHeaders: Default headers to include with every request. Defaults to empty dictionary.
     ///   - username: Username for HTTP Basic Authentication. Default is nil.
     ///   - password: Password for HTTP Basic Authentication. Default is nil.
     public init(
         baseURL: URL,
-        timeout: TimeInterval = 30.0,
+        timeout: TimeInterval = 60.0,
         defaultHeaders: [String: String] = [:],
         username: String? = nil,
         password: String? = nil
@@ -41,14 +41,14 @@ public struct LiveboxClientConfiguration {
     /// Creates a new configuration with a string URL.
     /// - Parameters:
     ///   - baseURLString: The base URL string for the router API. Should be a valid URL.
-    ///   - timeout: The timeout for network requests in seconds. Default is 30 seconds.
+    ///   - timeout: The timeout for network requests in seconds. Default is 60 seconds.
     ///   - defaultHeaders: Default headers to include with every request. Defaults to empty dictionary.
     ///   - username: Username for HTTP Basic Authentication. Default is nil.
     ///   - password: Password for HTTP Basic Authentication. Default is nil.
     /// - Throws: An error if the baseURLString is not a valid URL.
     public init(
         baseURLString: String,
-        timeout: TimeInterval = 30.0,
+        timeout: TimeInterval = 60.0,
         defaultHeaders: [String: String] = [:],
         username: String? = nil,
         password: String? = nil

--- a/Sources/Livebox/Livebox.swift
+++ b/Sources/Livebox/Livebox.swift
@@ -77,5 +77,5 @@ import Foundation
 /// - `Capabilities`: Router API capabilities and features
 public struct LiveboxInfo {
     /// The current version of the Livebox package.
-    public static let version = "1.4.0"
+    public static let version = "1.5.0"
 }

--- a/Tests/LiveboxTests/Client/LiveboxClientTests.swift
+++ b/Tests/LiveboxTests/Client/LiveboxClientTests.swift
@@ -12,7 +12,7 @@ struct LiveboxClientTests {
         let config = LiveboxClientConfiguration(baseURL: url)
 
         #expect(config.baseURL == url)
-        #expect(config.timeout == 30.0)
+        #expect(config.timeout == 60.0)
         #expect(config.defaultHeaders.isEmpty)
     }
 


### PR DESCRIPTION
This PR fixes some inconsistencies with the Livebox Fibra router and increases the timeout to 60 seconds